### PR TITLE
trees_biomass fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Point Cloud Data to Forest Inventory Tree List
-Version: 0.6.2
+Version: 0.6.3
 Author: George Woolsey, Colorado State University
 Maintainer: <george.woolsey@colostate.edu>
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # cloud2trees 0.6.3
 
-- Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utiliy function in R/utils_biomass.R
+- Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utility function in R/utils_biomass.R
 
 # cloud2trees 0.6.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cloud2trees 0.6.3
 
+- Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utiliy function in R/utils_biomass.R
+
 # cloud2trees 0.6.2
 
 Several methods for attaching tree component metrics involve modelling missing values using a random forest model. The computational cost of random forests is driven by the repeated tree building process, which involves recursive partitioning, bootstrapping, and feature subset selection. When performed on XXL tree lists (e.g. 100k+) these operations result in a significant computational burden. Furthermore, large data sets can exceed the available RAM, leading to disk swapping, which significantly slows down the computation. To mitigate those memory problems when using `randomForest::randomForest()`, these updates implement data subsampling for large data sets to reduce memory consumption by randomly sampling a representative subset of the training data. This process is iterated with different subsets and the results are combined via model averaging. Model averaging is a technique for improving the robustness and accuracy of random forest models, especially when dealing with large data sets.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.6.3
+
 # cloud2trees 0.6.2
 
 Several methods for attaching tree component metrics involve modelling missing values using a random forest model. The computational cost of random forests is driven by the repeated tree building process, which involves recursive partitioning, bootstrapping, and feature subset selection. When performed on XXL tree lists (e.g. 100k+) these operations result in a significant computational burden. Furthermore, large data sets can exceed the available RAM, leading to disk swapping, which significantly slows down the computation. To mitigate those memory problems when using `randomForest::randomForest()`, these updates implement data subsampling for large data sets to reduce memory consumption by randomly sampling a representative subset of the training data. This process is iterated with different subsets and the results are combined via model averaging. Model averaging is a technique for improving the robustness and accuracy of random forest models, especially when dealing with large data sets.

--- a/R/trees_cbh.R
+++ b/R/trees_cbh.R
@@ -306,7 +306,8 @@ trees_cbh <- function(
       )) %>%
       dplyr::select(
         treeID, tree_height_m, tree_cbh_m, is_training_cbh, tidyselect::ends_with("_zzz")
-      )
+      ) %>%
+      dplyr::filter(is_training_cbh==T)
   }else if(inherits(cbh_df, "data.frame")){
     cbh_df <- cbh_df %>%
       dplyr::mutate(dplyr::across(
@@ -315,7 +316,8 @@ trees_cbh <- function(
       )) %>%
       dplyr::select(
         treeID, tree_height_m, tree_cbh_m, is_training_cbh, tidyselect::ends_with("_zzz")
-      )
+      ) %>%
+      dplyr::filter(is_training_cbh==T)
   }else{
     stop("error extracting CBH")
   }

--- a/R/trees_hmd.R
+++ b/R/trees_hmd.R
@@ -219,13 +219,15 @@ trees_hmd <- function(
       dplyr::mutate(dplyr::across(
         .cols = c(tree_height_m, max_crown_diam_height_m, tidyselect::ends_with("_zzz"))
         , .fns = as.numeric
-      ))
+      )) %>%
+      dplyr::filter(is_training_hmd==T)
   }else if(inherits(hmd_df, "data.frame")){
     hmd_df <- hmd_df %>%
       dplyr::mutate(dplyr::across(
         .cols = c(tree_height_m, max_crown_diam_height_m, tidyselect::ends_with("_zzz"))
         , .fns = as.numeric
-      ))
+      )) %>%
+      dplyr::filter(is_training_hmd==T)
   }else{
     stop("error extracting HMD")
   }

--- a/R/utils_biomass.R
+++ b/R/utils_biomass.R
@@ -75,11 +75,15 @@ get_cruz_stand_kg_per_m3 <- function(forest_type_group_code, basal_area_m2_per_h
       poly_vect <- poly %>%
         sf::st_union() %>%
         sf::st_transform(terra::crs(rast)) %>%
-        terra::vect()
+        terra::vect() %>%
+        # buffer by 1/2 of cell width to avoid calling the edge as no overlap
+        terra::buffer(round(terra::res(rast)[1]*0.5))
     }else if(inherits(poly, "SpatVector")){
       poly_vect <- poly %>%
         terra::union() %>%
-        terra::project(terra::crs(rast))
+        terra::project(terra::crs(rast)) %>%
+        # buffer by 1/2 of cell width to avoid calling the edge as no overlap
+        terra::buffer(round(terra::res(rast)[1]*0.5))
     }else{
       stop("must pass a spatial SpatVector or sf object to `poly`")
     }


### PR DESCRIPTION
- Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utility function in R/utils_biomass.R