### PR TITLE
fix ladderfuelsr_cbh()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Point Cloud Data to Forest Inventory Tree List
-Version: 0.6.3
+Version: 0.6.4
 Author: George Woolsey, Colorado State University
 Maintainer: <george.woolsey@colostate.edu>
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cloud2trees 0.6.4
 
+- Fix: `ladderfuelsr_cbh()` would fail when using the `las` parameter due to the lack of proper reference to the `pointsByZSlice()` function from the `leafR` package ([https://github.com/DRAAlmeida/leafR](https://github.com/DRAAlmeida/leafR)). This error is within the `leafR` package and as a workaround we define the global variable as `pointsByZSlice <<- leafR::pointsByZSlice`. Eventually, `ladderfuelsr_cbh()` needs to break the reliance on the `leafR` package.
+- Fix: implements the internal function `as_character_safe()` defined in R/check_spatial_points.R to convert numeric columns to character which are meant to be used as a table identifier (i.e. as in "primary key") by ensuring that the number is not cast as character in scientific notation. To see the difference, compare `as.character(1000000000)` to `as_character_safe(1000000000)`.
+
 # cloud2trees 0.6.3
 
 - Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utility function in R/utils_biomass.R

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.6.4
+
 # cloud2trees 0.6.3
 
 - Fix: `trees_biomass()` (and the `trees_biomass_*()` functions) would return NA biomass values for trees that fell within a raster cell that *exactly* bordered the extent of the tree list. This change calculates the biomass for these border trees as if half of the raster cell (i.e. forest "stand") is within the study extent by updating the `calc_rast_cell_overlap()` utility function in R/utils_biomass.R

--- a/R/ladderfuelsr_cbh.R
+++ b/R/ladderfuelsr_cbh.R
@@ -247,9 +247,6 @@ ladderfuelsr_cbh <- function(
           , "\n"
           , "try `pak::pak(\"DRAAlmeida/leafR\", upgrade = TRUE)`"
         ))
-      }else{
-        # leafR does not have function reference in its coding and calls this nefarious "pointsByZSlice"
-        pointsByZSlice <<- leafR::pointsByZSlice
       }
 
       # check if string to las/laz file
@@ -740,3 +737,35 @@ ladderfuelsr_cbh <- function(
       ))
 
 }
+#############################################################
+# leafR does not have function reference in its coding and calls this nefarious "pointsByZSlice"
+pointsByZSlice <<- leafR::pointsByZSlice
+# # see: https://github.com/DRAAlmeida/leafR/blob/fd1456b9692ba7b5d5ba94ae88216046c8ec186f/R/main.R#L11
+## sets this function as global so that it works in leafR commands
+# pointsByZSlice <<- function(Z, maxZ){
+#     heightSlices = as.integer(Z) # Round down
+#     zSlice = data.table::data.table(Z=Z, heightSlices=heightSlices) # Create a data.table (Z, slices))
+#     sliceCount = stats::aggregate(list(V1=Z), list(heightSlices=heightSlices), length) # Count number of returns by slice
+#
+#     ##############################################
+#     # Add columns to equalize number of columns
+#     ##############################################
+#     colRange = 0:maxZ
+#     addToList = setdiff(colRange, sliceCount$heightSlices)
+#     n = length(addToList)
+#     if (n > 0) {
+#       bindDt = data.frame(heightSlices = addToList, V1=integer(n))
+#       sliceCount = rbind(sliceCount, bindDt)
+#       # Order by height
+#       sliceCount = sliceCount[order(sliceCount$heightSlices),]
+#     }
+#
+#     colNames = as.character(sliceCount$heightSlices)
+#     colNames[1] = "ground_0_1m"
+#     colNames[-1] = paste0("pulses_", colNames[-1], "_", sliceCount$heightSlices[-1]+1, "m")
+#     metrics = list()
+#     metrics[colNames] = sliceCount$V1
+#
+#     return(metrics)
+#
+#   } #end function pointsByZSlice

--- a/R/raster2trees.R
+++ b/R/raster2trees.R
@@ -163,7 +163,7 @@ raster2trees <- function(
     crowns_sf <- crowns_sf %>%
       dplyr::bind_rows(keep_buffer_crowns_temp) %>%
       # generate tree id
-      dplyr::mutate(treeID = dplyr::row_number() %>% as.character()) %>%
+      dplyr::mutate(treeID = dplyr::row_number() %>% as_character_safe()) %>%
       dplyr::relocate(treeID)
 
     # join tree tops

--- a/R/trees_biomass_cruz.R
+++ b/R/trees_biomass_cruz.R
@@ -242,7 +242,7 @@ trees_biomass_cruz <- function(
       ) %>%
       dplyr::mutate(dplyr::across(
         dplyr::everything()
-        , as.character
+        , as_character_safe
       ))
 
   ##################################

--- a/R/trees_cbh.R
+++ b/R/trees_cbh.R
@@ -399,7 +399,7 @@ trees_cbh <- function(
   if(!inherits(cbh_df$treeID, id_class)){
     if(id_class=="character"){
       cbh_df <- cbh_df %>%
-        dplyr::mutate(treeID = as.character(treeID))
+        dplyr::mutate(treeID = as_character_safe(treeID))
     }
     if(id_class=="numeric"){
       cbh_df <- cbh_df %>%

--- a/R/trees_dbh.R
+++ b/R/trees_dbh.R
@@ -215,7 +215,7 @@ trees_dbh <- function(
     tm_id_weight_temp <- terra::freq(treemap_rast) %>%
       dplyr::select(-layer) %>%
       dplyr::rename(tm_id = value, tree_weight = count) %>%
-      dplyr::mutate(tm_id = as.character(tm_id))
+      dplyr::mutate(tm_id = as_character_safe(tm_id))
     # str(tm_id_weight_temp)
 
     ### get the TreeMap FIA tree list for only the plots included
@@ -234,8 +234,8 @@ trees_dbh <- function(
       ) %>%
       dplyr::rename_with(tolower) %>%
       dplyr::mutate(
-        cn = as.character(cn)
-        , tm_id = as.character(tm_id)
+        cn = as_character_safe(cn)
+        , tm_id = as_character_safe(tm_id)
       ) %>%
       dplyr::left_join(
         tm_id_weight_temp
@@ -359,7 +359,7 @@ trees_dbh <- function(
         , fia_est_dbh_cm_lower = lower_b
         , fia_est_dbh_cm_upper = upper_b
       ) %>%
-      dplyr::mutate(tree_height_m_tnth=as.character(tree_height_m_tnth)) %>%
+      dplyr::mutate(tree_height_m_tnth=as_character_safe(tree_height_m_tnth)) %>%
       dplyr::relocate(tree_height_m_tnth)
     # str(pred_mod_nl_pop_temp)
 
@@ -374,7 +374,7 @@ trees_dbh <- function(
     tree_tops <- tree_tops %>%
       # join with model predictions at 0.1 m height intervals
         dplyr::mutate(
-          tree_height_m_tnth = round(as.numeric(tree_height_m),1) %>% as.character()
+          tree_height_m_tnth = round(as.numeric(tree_height_m),1) %>% as_character_safe()
         ) %>%
         dplyr::left_join(
           pred_mod_nl_pop_temp
@@ -427,7 +427,7 @@ trees_dbh <- function(
       crowns_sf_joined_stems_temp <- crowns_sf_joined_stems_temp %>%
         # join with model predictions at 0.1 m height intervals
         dplyr::mutate(
-          tree_height_m_tnth = round(as.numeric(tree_height_m),1) %>% as.character()
+          tree_height_m_tnth = round(as.numeric(tree_height_m),1) %>% as_character_safe()
         ) %>%
         dplyr::inner_join(
           pred_mod_nl_pop_temp

--- a/R/trees_hmd.R
+++ b/R/trees_hmd.R
@@ -100,7 +100,7 @@ trees_hmd <- function(
   , norm_las = NULL
   , tree_sample_n = NA
   , tree_sample_prop = NA
-  , estimate_missing_hmd = F
+  , estimate_missing_hmd = TRUE
   , force_same_crs = F
 ){
   # could move to parameters

--- a/R/trees_hmd.R
+++ b/R/trees_hmd.R
@@ -312,7 +312,7 @@ trees_hmd <- function(
   if(!inherits(hmd_df$treeID, id_class)){
     if(id_class=="character"){
       hmd_df <- hmd_df %>%
-        dplyr::mutate(treeID = as.character(treeID))
+        dplyr::mutate(treeID = as_character_safe(treeID))
     }
     if(id_class=="numeric"){
       hmd_df <- hmd_df %>%

--- a/R/trees_type.R
+++ b/R/trees_type.R
@@ -109,7 +109,7 @@ trees_type <- function(
       ) %>%
       dplyr::mutate(dplyr::across(
         dplyr::everything()
-        , as.character
+        , as_character_safe
       ))
 
   ####################################################################
@@ -133,7 +133,7 @@ trees_type <- function(
     # # let's check with the lookup table
     na_trees <- crop_raster_match_points_ans$point_values %>%
       dplyr::mutate(
-        forest_type_code = raster_value %>% as.character()
+        forest_type_code = raster_value %>% as_character_safe()
       ) %>%
       dplyr::left_join(foresttype_lookup, by = "forest_type_code") %>%
       dplyr::filter(is.na(forest_type_group_code)) %>%
@@ -178,7 +178,7 @@ trees_type <- function(
       # now let's join it back with our data and check it
       tree_tops <- tree_tops %>%
         dplyr::mutate(
-          forest_type_code = point_values_from_rast$raster_value %>% as.character()
+          forest_type_code = point_values_from_rast$raster_value %>% as_character_safe()
         ) %>%
         dplyr::left_join(
           foresttype_lookup %>%

--- a/R/utils_cbh.R
+++ b/R/utils_cbh.R
@@ -1025,7 +1025,7 @@ output_ctg_for_ladderfuelsr_cbh <- function(
   if(!inherits(lad_profile$treeID, id_class)){
     if(id_class=="character"){
       lad_profile <- lad_profile %>%
-        dplyr::mutate(treeID = as.character(treeID))
+        dplyr::mutate(treeID = as_character_safe(treeID))
     }
     if(id_class=="numeric"){
       lad_profile <- lad_profile %>%
@@ -1088,10 +1088,10 @@ clean_cbh_df <- function(cbh_df = NULL, trees_poly, lad_profile, force_cbh_lte_h
     # and update treeID if made backup
     if(names(lad_profile) %>% stringr::str_equal("treeID_bu") %>% any()){
       cbh_df <- cbh_df %>%
-        dplyr::mutate(treeID=as.character(treeID)) %>%
+        dplyr::mutate(treeID=as_character_safe(treeID)) %>%
         dplyr::inner_join(
           lad_profile %>% dplyr::distinct(treeID_bu, treeID, total_pulses) %>%
-            dplyr::mutate(treeID=as.character(treeID))
+            dplyr::mutate(treeID=as_character_safe(treeID))
           , by = "treeID"
         ) %>%
         dplyr::mutate(

--- a/R/utils_hmd.R
+++ b/R/utils_hmd.R
@@ -240,7 +240,7 @@ trees_hmd_sf <- function(
     if(!inherits(hmd_df$treeID, id_class)){
       if(id_class=="character"){
         hmd_df <- hmd_df %>%
-          dplyr::mutate(treeID = as.character(treeID))
+          dplyr::mutate(treeID = as_character_safe(treeID))
       }
       if(id_class=="numeric"){
         hmd_df <- hmd_df %>%

--- a/man/trees_hmd.Rd
+++ b/man/trees_hmd.Rd
@@ -9,7 +9,7 @@ trees_hmd(
   norm_las = NULL,
   tree_sample_n = NA,
   tree_sample_prop = NA,
-  estimate_missing_hmd = F,
+  estimate_missing_hmd = TRUE,
   force_same_crs = F
 )
 }


### PR DESCRIPTION
- Fix: `ladderfuelsr_cbh()` would fail when using the `las` parameter due to the lack of proper reference to the `pointsByZSlice()` function from the `leafR` package ([https://github.com/DRAAlmeida/leafR](https://github.com/DRAAlmeida/leafR)). This error is within the `leafR` package and as a workaround we define the global variable as `pointsByZSlice <<- leafR::pointsByZSlice`. Eventually, `ladderfuelsr_cbh()` needs to break the reliance on the `leafR` package.
- Fix: implements the internal function `as_character_safe()` defined in R/check_spatial_points.R to convert numeric columns to character which are meant to be used as a table identifier (i.e. as in "primary key") by ensuring that the number is not cast as character in scientific notation. To see the difference, compare `as.character(1000000000)` to `as_character_safe(1000000000)`.