### PR TITLE
fix trees_biomass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Point Cloud Data to Forest Inventory Tree List
-Version: 0.6.4
+Version: 0.6.5
 Author: George Woolsey, Colorado State University
 Maintainer: <george.woolsey@colostate.edu>
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.6.5
+
 # cloud2trees 0.6.4
 
 - Fix: `ladderfuelsr_cbh()` would fail when using the `las` parameter due to the lack of proper reference to the `pointsByZSlice()` function from the `leafR` package ([https://github.com/DRAAlmeida/leafR](https://github.com/DRAAlmeida/leafR)). This error is within the `leafR` package and as a workaround we define the global variable as `pointsByZSlice <<- leafR::pointsByZSlice`. Eventually, `ladderfuelsr_cbh()` needs to break the reliance on the `leafR` package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cloud2trees 0.6.5
 
+- Fix: `trees_biomass()` would refuse to overwrite values in "landfire_" and "cruz_" columns if those columns already existed in the data passed to the `tree_list`. This update now forces the overwrite of the data in these columns if already present in the data.
+
 # cloud2trees 0.6.4
 
 - Fix: `ladderfuelsr_cbh()` would fail when using the `las` parameter due to the lack of proper reference to the `pointsByZSlice()` function from the `leafR` package ([https://github.com/DRAAlmeida/leafR](https://github.com/DRAAlmeida/leafR)). This error is within the `leafR` package and as a workaround we define the global variable as `pointsByZSlice <<- leafR::pointsByZSlice`. Eventually, `ladderfuelsr_cbh()` needs to break the reliance on the `leafR` package.

--- a/R/ladderfuelsr_cbh.R
+++ b/R/ladderfuelsr_cbh.R
@@ -172,7 +172,9 @@ ladderfuelsr_cbh <- function(
           treeID = dplyr::coalesce(
               as.numeric(treeID)
               , round(as.numeric(Sys.time()) + round(runif(1)*100000))
-            ) %>% as.factor()
+            ) %>% 
+            as_character_safe() %>% 
+            as.factor()
         )
     }else if( # filter for the treeID
       (names(lad_profile_df) %>% stringr::str_equal("treeID") %>% any())
@@ -302,7 +304,9 @@ ladderfuelsr_cbh <- function(
       treeID <- dplyr::coalesce(
         as.numeric(treeID)[1]
         , round(as.numeric(Sys.time()) + round(runif(1)*100000))
-      ) %>% as.factor() # if the treeID parameter is not set, fake 1
+      ) %>% 
+      as_character_safe() %>% 
+      as.factor() # if the treeID parameter is not set, fake 1
       #######################################
       ### Step 0 - `leafR` steps
       #######################################

--- a/R/leafr_for_ladderfuelsr.R
+++ b/R/leafr_for_ladderfuelsr.R
@@ -399,7 +399,7 @@ voxelize_las_to_bbox_df <- function(
     dplyr::filter(
       !dplyr::if_all(
         .cols = dplyr::all_of(cols2group)
-        , .fns = ~ dplyr::coalesce(as.numeric(as.factor(.x)), 0) == 0
+        , .fns = ~ dplyr::coalesce(as.numeric(as.factor(as_character_safe(.x))), 0) == 0
       )
     )
 
@@ -462,43 +462,6 @@ voxelize_las_to_bbox_df <- function(
   return(grid_df)
 }
 
-# voxelize_las_to_bbox_df(las = las, attribute = c("treeID")) %>%
-#   dplyr::glimpse()
-# voxelize_las_to_bbox_df(las = las, attribute = "treeID") %>%
-#   dplyr::relocate(x,y,z) %>%
-#   dplyr::mutate(treeID = treeID %>% as.factor() %>% as.numeric()) %>%
-#   dplyr::rename_with(toupper) %>%
-#   lidR::LAS(crs = lidR::st_crs(las)) %>%
-#   lidR::plot(
-#     color="TREEID"
-#     , size = 1, bg = "white", voxel = TRUE
-#   )
-# voxelize_las_to_bbox_df(las = las, attribute = "treeID", full_z_range = F) %>%
-#   dplyr::relocate(x,y,z) %>%
-#   dplyr::mutate(treeID = treeID %>% as.factor() %>% as.numeric()) %>%
-#   dplyr::rename_with(toupper) %>%
-#   lidR::LAS(crs = lidR::st_crs(las)) %>%
-#   lidR::plot(
-#     color="TREEID"
-#     , size = 1, bg = "white", voxel = TRUE
-#   )
-# voxelize_las_to_bbox_df(las = las) %>%
-#   dplyr::relocate(x,y,z) %>%
-#   dplyr::rename_with(toupper) %>%
-#   lidR::LAS(crs = lidR::st_crs(las)) %>%
-#   lidR::plot(
-#     color="Z"
-#     , size = 1, bg = "white", voxel = TRUE
-#   )
-# voxelize_las_to_bbox_df(las = las, full_z_range = F) %>%
-#   dplyr::relocate(x,y,z) %>%
-#   dplyr::rename_with(toupper) %>%
-#   lidR::LAS(crs = lidR::st_crs(las)) %>%
-#   lidR::plot(
-#     color="Z"
-#     , size = 1, bg = "white", voxel = TRUE
-#   )
-
 #####################################################################
 # intermediate function 48:
 ## in order to join by our cols2group we need to create a single column
@@ -521,7 +484,7 @@ cols2group_to_id <- function(df, cols2group, as_factor = F) {
     dplyr::ungroup() %>%
     dplyr::mutate(dplyr::across(
       dplyr::all_of(cols2group)
-      , .fns = ~ factor(.x) %>% as.character()
+      , .fns = ~ as_character_safe(.x)
       , .names = "{.col}_fctxxx"
     ))
   ## 2. combine the cols2group columns into one id column
@@ -615,7 +578,7 @@ voxel_count_pulses <- function(
       dplyr::filter(
         !dplyr::if_all(
           .cols = dplyr::all_of(cols2group)
-          , .fns = ~ dplyr::coalesce(as.numeric(as.factor(.x)), 0) == 0
+          , .fns = ~ dplyr::coalesce(as.numeric(as.factor(as_character_safe(.x))), 0) == 0
         )
       )
 
@@ -782,18 +745,6 @@ voxel_count_pulses <- function(
     dplyr::relocate(dplyr::all_of(cols2group))
   # voxel_pulses_df %>% dplyr::glimpse()
   # voxel_pulses_df %>% summary()
-
-  # voxel_pulses_df %>%
-  #   dplyr::filter(pulses>0) %>%
-  #   dplyr::filter(treeID == voxel_pulses_df$treeID[5555]) %>%
-  #   dplyr::relocate(x,y,z) %>%
-  #   dplyr::mutate(treeID = treeID %>% as.factor() %>% as.numeric()) %>%
-  #   dplyr::rename_with(toupper) %>%
-  #   lidR::LAS(crs = lidR::st_crs(las)) %>%
-  #   lidR::plot(
-  #     color="PULSES", legend = T
-  #     , size = horizontal_res, bg = "white", voxel = TRUE
-  #   )
 
   # return
   return(voxel_pulses_df)

--- a/R/trees_biomass.R
+++ b/R/trees_biomass.R
@@ -158,6 +158,9 @@ trees_biomass <- function(
       ############################
       if(inherits(trees_biomass_cruz_ans$result$tree_list, "data.frame")){
         tl_cruz <- trees_biomass_cruz_ans$result$tree_list
+        # remove columns created in trees_biomass_cruz if already existed in orig data
+        tree_tops <- tree_tops %>%
+          clean_biomass_cols(method = "cruz")
         # get names from new df
         names_temp <- c(
           "treeID"
@@ -210,6 +213,9 @@ trees_biomass <- function(
       ############################
       if(inherits(trees_biomass_landfire_ans$result$tree_list, "data.frame")){
         tl_landfire <- trees_biomass_landfire_ans$result$tree_list
+        # remove columns created in trees_biomass_landfire if already existed in orig data
+        tree_tops <- tree_tops %>%
+          clean_biomass_cols(method = "landfire")
         # get names from new df
         names_temp <- c(
           "treeID"

--- a/R/trees_biomass_cruz.R
+++ b/R/trees_biomass_cruz.R
@@ -172,17 +172,7 @@ trees_biomass_cruz <- function(
 
   # get rid of columns we'll create
     tree_tops <- tree_tops %>%
-      # throw in hey_xxxxxxxxxx to test it works if we include non-existent columns
-      dplyr::select( -dplyr::any_of(c(
-        "hey_xxxxxxxxxx"
-        , "cruz_stand_id"
-        , "crown_dia_m"
-        , "crown_length_m"
-        , "crown_volume_m3"
-        , "cruz_tree_kg_per_m3"
-        , "cruz_stand_kg_per_m3"
-        , "cruz_crown_biomass_kg"
-      )))
+      clean_biomass_cols(method = "cruz")
 
   ##################################
   # ensure that we have forest_type_group_code

--- a/R/trees_biomass_landfire.R
+++ b/R/trees_biomass_landfire.R
@@ -163,17 +163,7 @@ trees_biomass_landfire <- function(
 
   # get rid of columns we'll create
     tree_tops <- tree_tops %>%
-      # throw in hey_xxxxxxxxxx to test it works if we include non-existent columns
-      dplyr::select( -dplyr::any_of(c(
-        "hey_xxxxxxxxxx"
-        , "landfire_stand_id"
-        , "crown_dia_m"
-        , "crown_length_m"
-        , "crown_volume_m3"
-        , "landfire_tree_kg_per_m3"
-        , "landfire_stand_kg_per_m3"
-        , "landfire_crown_biomass_kg"
-      )))
+      clean_biomass_cols(method = "landfire")
 
   ##################################
   # ensure that we have landfire_cell_kg_per_m3

--- a/R/utils_biomass.R
+++ b/R/utils_biomass.R
@@ -644,3 +644,42 @@ get_cruz_stand_kg_per_m3 <- function(forest_type_group_code, basal_area_m2_per_h
     return(T)
   }
 
+#######################################################
+# intermediate function 27
+#######################################################
+  # drop columns from df that will be created in a trees_biomass_*()
+  clean_biomass_cols <- function(df, method) {
+    # which_biomass_methods?
+    which_biomass_methods <- check_biomass_method(method)
+    # cruz columns
+    if( any(stringr::str_equal(which_biomass_methods, "cruz")) ){
+      df <- df %>%
+        # throw in hey_xxxxxxxxxx to test it works if we include non-existent columns
+        dplyr::select( -dplyr::any_of(c(
+          "hey_xxxxxxxxxx"
+          , "cruz_stand_id"
+          , "crown_dia_m"
+          , "crown_length_m"
+          , "crown_volume_m3"
+          , "cruz_tree_kg_per_m3"
+          , "cruz_stand_kg_per_m3"
+          , "cruz_crown_biomass_kg"
+        )))
+    }
+    # landfire columns
+    if( any(stringr::str_equal(which_biomass_methods, "landfire")) ){
+      df <- df %>%
+        # throw in hey_xxxxxxxxxx to test it works if we include non-existent columns
+        dplyr::select( -dplyr::any_of(c(
+          "hey_xxxxxxxxxx"
+          , "landfire_stand_id"
+          , "crown_dia_m"
+          , "crown_length_m"
+          , "crown_volume_m3"
+          , "landfire_tree_kg_per_m3"
+          , "landfire_stand_kg_per_m3"
+          , "landfire_crown_biomass_kg"
+        )))
+    }
+    return(df)
+  }


### PR DESCRIPTION
- Fix: `trees_biomass()` would refuse to overwrite values in "landfire_" and "cruz_" columns if those columns already existed in the data passed to the `tree_list`. This update now forces the overwrite of the data in these columns if already present in the data.