### PR TITLE
updates point cloud noise filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Point Cloud Data to Forest Inventory Tree List
-Version: 0.6.7
+Version: 0.6.8
 Author: George Woolsey, Colorado State University
 Maintainer: <george.woolsey@colostate.edu>
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.6.8
+
 # cloud2trees 0.6.7
 
 - Fix: `itd_tuning()` now accounts for possible data transformation that occurs in `raster2trees()` on State Plane Coordinate System (SPCS) zone projections which use U.S. survey feet to express eastings and northings

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cloud2trees 0.6.8
 
+- Change: `cloud2raster()` now implements noise removal from the point cloud prior to the ground classification stage (in addition to after the stage) to minimize the influence of egregious outlier points on classification
+
 # cloud2trees 0.6.7
 
 - Fix: `itd_tuning()` now accounts for possible data transformation that occurs in `raster2trees()` on State Plane Coordinate System (SPCS) zone projections which use U.S. survey feet to express eastings and northings

--- a/R/lasr_pipeline.R
+++ b/R/lasr_pipeline.R
@@ -100,7 +100,7 @@ lasr_pipeline <- function(
     # denoise
     ###################
       # classify isolated points
-      lasr_denoise <- lasR::classify_with_ivf(res =  5, n = 6)
+      lasr_denoise <- lasR::classify_with_ivf(res =  5, n = 9L) + lasR::delete_noise()
     ###################
     # write
     ###################
@@ -122,6 +122,7 @@ lasr_pipeline <- function(
   if(keep_intrmdt == T){
     # pipeline
       lasr_pipeline_temp <- lasr_read +
+        lasr_denoise +
         lasr_classify +
         lasr_denoise +
         lasr_write_classify +
@@ -142,6 +143,7 @@ lasr_pipeline <- function(
   }else{
     # pipeline
       lasr_pipeline_temp <- lasr_read +
+        lasr_denoise +
         lasr_classify +
         lasr_denoise +
         lasr_dtm_norm(


### PR DESCRIPTION
- Change: `cloud2raster()` now implements noise removal from the point cloud prior to the ground classification stage (in addition to after the stage) to minimize the influence of egregious outlier points on classification