### PR TITLE
saves hmd and cbh models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Point Cloud Data to Forest Inventory Tree List
-Version: 0.6.8
+Version: 0.6.9
 Author: George Woolsey, Colorado State University
 Maintainer: <george.woolsey@colostate.edu>
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # cloud2trees 0.6.9
 
+Saving models used to estimate missing HMD and CBH values. Note, in the actual missing value estimation many RF models are estimated and model averaging is used. However, only the first estimated model is saved in this new export functionality which does not fully represent the process used to fill in missing values.
+
+- Change: `trees_hmd()` now saves the model used to estimate missing HMD values to the path specified in `outfolder` if the parameter `estimate_missing_hmd = T`
+- Change: `trees_cbh()` now saves the model used to estimate missing HMD values to the path specified in `outfolder` if the parameter `estimate_missing_hmd = T`
+- Change: `cloud2trees()` automatically saves the model used to estimate missing HMD and CBH values to the `point_cloud_processing_delivery` directory
+
 # cloud2trees 0.6.8
 
 - Change: `cloud2raster()` now implements noise removal from the point cloud prior to the ground classification stage (in addition to after the stage) to minimize the influence of egregious outlier points on classification

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.6.9
+
 # cloud2trees 0.6.8
 
 - Change: `cloud2raster()` now implements noise removal from the point cloud prior to the ground classification stage (in addition to after the stage) to minimize the influence of egregious outlier points on classification

--- a/R/cloud2trees.R
+++ b/R/cloud2trees.R
@@ -539,6 +539,7 @@ cloud2trees <- function(
       , min_lad_pct = cbh_min_lad_pct
       , frst_layer_min_ht_m = cbh_frst_layer_min_ht_m
       , force_same_crs = T
+      , outfolder = cloud2raster_ans$create_project_structure_ans$delivery_dir
     )
     # handle error
     if(is.null(trees_cbh_ans$error)){ # no error
@@ -643,6 +644,7 @@ cloud2trees <- function(
       , tree_sample_prop = hmd_tree_sample_prop
       , estimate_missing_hmd = hmd_estimate_missing_hmd
       , force_same_crs = T
+      , outfolder = cloud2raster_ans$create_project_structure_ans$delivery_dir
     )
     # handle error
     if(is.null(trees_hmd_ans$error)){ # no error

--- a/R/trees_cbh.R
+++ b/R/trees_cbh.R
@@ -40,6 +40,9 @@
 #' @param frst_layer_min_ht_m numeric. value for the depth height of the first fuel layer. If the first fuel layer has the maximum LAD and its depth is greater than the indicated value, then this fuel layer is considered as the CBH of the tree. On the contrary, if its depth is <= the value, the CBH with maximum LAD will be the second fuel layer, although it has not the maximum LAD. See `hdepth1_height` in [LadderFuelsR::get_cbh_metrics()]
 #' @param force_same_crs logical. force the same crs between the point cloud and polygon if confident that data are in same projection.
 #' data created by a `cloud2trees` pipeline (e.g. [cloud2raster()]) will always have the same projection even if not recognized by `lidR` functions
+#' @param outfolder string. The path of a folder to write the model data to.
+#'   Note, in the actual missing value estimation many RF models are estimated and model averaging is used.
+#'   However, only the first estimated model is saved in this export which does not fully represent the process used to fill in missing values.
 #'
 #' @references
 #' * [https://doi.org/10.1111/2041-210X.14427](https://doi.org/10.1111/2041-210X.14427)
@@ -136,6 +139,7 @@ trees_cbh <- function(
   , min_lad_pct = 10
   , frst_layer_min_ht_m = 1
   , force_same_crs = F
+  , outfolder = tempdir()
 ){
   # could move to parameters
   force_cbh_lte_ht <- T
@@ -348,6 +352,13 @@ trees_cbh <- function(
       , mod_n_subsample = estimate_missing_max_n_training
       , mod_n_times = ntimes_temp
     )
+    # write just the first model
+    if(
+      !is.null(cbh_mod)
+      && length(cbh_mod)>0
+    ){
+      saveRDS(cbh_mod[[1]], file = file.path(normalizePath(outfolder), "cbh_height_model_estimates.rds"))
+    }
   }else{
     cbh_mod <- NULL
   }

--- a/R/trees_hmd.R
+++ b/R/trees_hmd.R
@@ -29,6 +29,9 @@
 #'   Should the missing HMD values be estimated using the tree height and location information based on trees for which HMD is successfully extracted?
 #' @param force_same_crs logical. force the same crs between the point cloud and polygon if confident that data are in same projection.
 #' data created by a `cloud2trees` pipeline (e.g. [cloud2raster()]) will always have the same projection even if not recognized by `lidR` functions
+#' @param outfolder string. The path of a folder to write the model data to.
+#'   Note, in the actual missing value estimation many RF models are estimated and model averaging is used.
+#'   However, only the first estimated model is saved in this export which does not fully represent the process used to fill in missing values.
 #'
 #' @references
 #' An early version of this process was developed by [Andrew Sanchez Meador](https://github.com/bi0m3trics).
@@ -102,6 +105,7 @@ trees_hmd <- function(
   , tree_sample_prop = NA
   , estimate_missing_hmd = TRUE
   , force_same_crs = F
+  , outfolder = tempdir()
 ){
   # could move to parameters
   force_hmd_lte_ht <- T
@@ -261,6 +265,13 @@ trees_hmd <- function(
       , mod_n_subsample = estimate_missing_max_n_training
       , mod_n_times = ntimes_temp
     )
+    # write just the first model
+    if(
+      !is.null(hmd_mod)
+      && length(hmd_mod)>0
+    ){
+      saveRDS(hmd_mod[[1]], file = file.path(normalizePath(outfolder), "hmd_height_model_estimates.rds"))
+    }
   }else{
     hmd_mod <- NULL
   }

--- a/man/trees_cbh.Rd
+++ b/man/trees_cbh.Rd
@@ -20,7 +20,8 @@ trees_cbh(
   num_jump_steps = 1,
   min_lad_pct = 10,
   frst_layer_min_ht_m = 1,
-  force_same_crs = F
+  force_same_crs = F,
+  outfolder = tempdir()
 )
 }
 \arguments{
@@ -69,6 +70,10 @@ Should the missing CBH values be estimated using the tree height and location in
 
 \item{force_same_crs}{logical. force the same crs between the point cloud and polygon if confident that data are in same projection.
 data created by a \code{cloud2trees} pipeline (e.g. \code{\link[=cloud2raster]{cloud2raster()}}) will always have the same projection even if not recognized by \code{lidR} functions}
+
+\item{outfolder}{string. The path of a folder to write the model data to.
+Note, in the actual missing value estimation many RF models are estimated and model averaging is used.
+However, only the first estimated model is saved in this export which does not fully represent the process used to fill in missing values.}
 }
 \value{
 Returns a spatial data frame of individual trees.

--- a/man/trees_hmd.Rd
+++ b/man/trees_hmd.Rd
@@ -10,7 +10,8 @@ trees_hmd(
   tree_sample_n = NA,
   tree_sample_prop = NA,
   estimate_missing_hmd = TRUE,
-  force_same_crs = F
+  force_same_crs = F,
+  outfolder = tempdir()
 )
 }
 \arguments{
@@ -34,6 +35,10 @@ Should the missing HMD values be estimated using the tree height and location in
 
 \item{force_same_crs}{logical. force the same crs between the point cloud and polygon if confident that data are in same projection.
 data created by a \code{cloud2trees} pipeline (e.g. \code{\link[=cloud2raster]{cloud2raster()}}) will always have the same projection even if not recognized by \code{lidR} functions}
+
+\item{outfolder}{string. The path of a folder to write the model data to.
+Note, in the actual missing value estimation many RF models are estimated and model averaging is used.
+However, only the first estimated model is saved in this export which does not fully represent the process used to fill in missing values.}
 }
 \value{
 Returns a spatial data frame of individual trees with the added columns: \code{max_crown_diam_height_m}, \code{is_training_hmd}


### PR DESCRIPTION
Saving models used to estimate missing HMD and CBH values. Note, in the actual missing value estimation many RF models are estimated and model averaging is used. However, only the first estimated model is saved in this new export functionality which does not fully represent the process used to fill in missing values.

- Change: `trees_hmd()` now saves the model used to estimate missing HMD values to the path specified in `outfolder` if the parameter `estimate_missing_hmd = T`
- Change: `trees_cbh()` now saves the model used to estimate missing HMD values to the path specified in `outfolder` if the parameter `estimate_missing_hmd = T`
- Change: `cloud2trees()` automatically saves the model used to estimate missing HMD and CBH values to the `point_cloud_processing_delivery` directory