### PR TITLE
enhance point cloud noise filtering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Aerial point cloud data to forest inventory tree lists
-Version: 0.7.9
+Version: 0.8.0
 Authors@R: 
     person("George", "Woolsey", , "george.woolsey@colostate.edu", role = c("aut", "cre"))
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,4 @@ Config/Needs/website: rmarkdown
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # cloud2trees 0.8.0
 
+- Change: introduces `noise_level` parameter to `cloud2raster()` and `cloud2trees()` to update the point cloud noise filtering workflow and gives users control over the algorithm and strictness used to better address persistent raster artifacts.
+- Change: `cloud2trees()` checks to ensure alignment between the `*_estimate_missing_*` and `estimate_tree_*` parameters. If `cbh_estimate_missing_cbh = T`, then the program automatically enables `estimate_tree_cbh` and the same applies for the `hmd_` settings. Users should still define a sample size (`*_tree_sample_n` or `*_tree_sample_prop`) for estimating these tree attributes, if none is defined the default is to use a small sample for estimation to limit processing time.
+
+`noise_level` is a tiered parameter added to `cloud2raster()` and `cloud2trees()` which gives users control over the noise detection algorithm and strictness used to resolve artifacts in rasterized data products. The new options include a statistical outlier removal (SOR) algorithm which identifies noise by calculating the mean distance from each point to its nearest neighbors. The workflow continues to remove all vendor-classified noise from the raw point cloud prior to subsequent processing. The `noise_level` allows users to control additional noise cleaning based on the specific quality of the dataset. This provides users with a way to mitigate issues if initial rasterized outputs (CHM, DTM) include persistent pits or spikes. `noise_level = 2` (the default) uses a fine-scale SOR filter with 15 neighbors and a 3 standard deviation threshold (3-sigma rule) to find outliers based on the local neighborhood. `noise_level = 3` adds a global noise detection pass prior to the local pass by first using 50 neighbors to identify points or clusters that are statistically far from the main cloud mass. While `noise_level = 2` does not consistently increase processing time, `noise_level = 3` will generally result in longer runtimes, especially for high-density data, because it is a multi-scale noise removal routine that analyzes larger groups of points simultaneously.
+
+**`noise_level` settings:**
+
+1. `noise_level = 1` (legacy): uses `lasR::classify_with_ivf(res = 5, n = 9)` and is maintained for legacy consistency and backward compatibility.
+2. `noise_level = 2` (fine-scale SOR): the default setting implements `lasR::classify_with_sor()` with a neighborhood of 15 points (k = 15) and a threshold of 3 standard deviations (m = 3) is used for standard cleaning across varying point densities.
+3. `noise_level = 3` (multi-scale SOR): uses a dual-pass noise filtering approach by first applying a coarse-scale filter (k = 50, m = 4) to identify points or clusters that are far from the main cloud mass and then a fine-scale filter (k = 15, m = 3) for local cleaning.
+
 # cloud2trees 0.7.9
 
 - Change: updates utility functions for working with very large raster data in internal workflow for potential future release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.8.0
+
 # cloud2trees 0.7.9
 
 - Change: updates utility functions for working with very large raster data in internal workflow for potential future release

--- a/R/cloud2raster.R
+++ b/R/cloud2raster.R
@@ -22,6 +22,14 @@
 #' @param chm_res_m numeric. The desired resolution of the CHM produced in meters.
 #' @param min_height numeric. Set the minimum height (m) for individual tree detection
 #' @param max_height numeric. Set the maximum height (m) for the canopy height model
+#' @param noise_level numeric. Choose point cloud noise reduction level 1, 2, or 3. Use a higher noise level for point clouds with more noise
+#'    which tend to produce raster outputs with pits or spikes that are too severe to be filled with standard post-processing.
+#'    The default level of 2 has similar processing time compared to level to 1
+#'    but uses a more broadly applicable noise detection algorithm. Level 3 takes 10-40% longer to process.
+#'   * noise_level = 1 uses isolated voxel filter (IVF) with a resolution of 5 voxels and 9 other points to identify noise
+#'   * noise_level = 2 uses a single-pass, fine-scale statistical outlier removal (SOR) that primarily targets local noise
+#'   * noise_level = 3 uses a muli-pass statistical outlier removal (SOR) that first applies a coarse-scale filter
+#'    to find points/clusters far from the main cloud mass and then applies a fine-scale filter to identify local noise
 #' @param overwrite logical. Should the output files in the `point_cloud_processing_delivery` directory from previous iterations be deleted?
 #'
 #' @references
@@ -72,6 +80,7 @@ cloud2raster <- function(
   , chm_res_m = 0.25
   , min_height = 2
   , max_height = 70
+  , noise_level = 2
   , overwrite = TRUE
 ){
   ######################################
@@ -170,6 +179,7 @@ cloud2raster <- function(
           , chm_res_m = chm_res_m
           , min_height = min_height
           , max_height = max_height
+          , noise_level = noise_level
           , dtm_dir = config$dtm_dir
           , chm_dir = config$chm_dir
           , classify_dir = config$las_classify_dir
@@ -246,11 +256,7 @@ cloud2raster <- function(
             chunk_las_catalog_ans$las_ctg@data$geometry %>%
               sf::st_union() %>%
               terra::vect()
-          ) %>%
-          terra::mask(
-            chunk_las_catalog_ans$las_ctg@data$geometry %>%
-              sf::st_union() %>%
-              terra::vect()
+            , mask = T
           ) %>%
           terra::focal(
             w = 3
@@ -264,7 +270,7 @@ cloud2raster <- function(
           )
         # chm_rast %>% terra::crs()
         # chm_rast %>% terra::plot()
-
+      names(chm_rast) <- "chm"
       # write to delivery directory
         terra::writeRaster(
           chm_rast

--- a/R/cloud2raster.R
+++ b/R/cloud2raster.R
@@ -7,7 +7,7 @@
 #'
 #' * Tile the raw point cloud to work with smaller chunks and reduce the potential for memory issues with high density clouds using [chunk_las_catalog()]
 #' * Classify the point cloud using [lasR::classify_with_csf()]
-#' * Remove outlier points using [lasR::classify_with_ivf()]
+#' * Remove outlier points using [lasR::classify_with_sor()]
 #' * Produce a triangulation of the ground points (meshed DTM) using [lasR::triangulate()]
 #' * Rasterize the result of the Delaunay triangulation using [lasR::rasterize()] to create a DTM
 #' * Height normalize the point cloud using either the DTM or the triangulation [lasR::transform_with()]

--- a/R/cloud2trees.R
+++ b/R/cloud2trees.R
@@ -56,7 +56,7 @@
 #' who found the dry bulk density of the tree crown was 2.6 kilograms per cubed meter
 #' using Douglas-fir trees grown on Christmas tree farms.
 #' Set this parameter to a large value (e.g. 1e10) or NULL to avoid limiting tree crown CBD.
-#' @param estimate_tree_cbh logical. Should tree DBH be estimated? See [trees_cbh()].
+#' @param estimate_tree_cbh logical. Should tree CBH be estimated? See [trees_cbh()].
 #'   Make sure to set `cbh_estimate_missing_cbh = TRUE` if you want to obtain CBH values for cases when CBH cannot be extracted from the point cloud.
 #' @param cbh_tree_sample_n,cbh_tree_sample_prop numeric. Provide either `tree_sample_n`, the number of trees, or `tree_sample_prop`, the
 #'   proportion of the trees to attempt to extract a CBH from the point cloud for.
@@ -197,6 +197,13 @@ cloud2trees <- function(
     }
     if(any(stringr::str_equal(which_biomass_methods, "cruz"))){
       estimate_tree_type <- T
+    }
+    ### for HMD and CBH, make sure T/F switches match
+    if(cbh_estimate_missing_cbh){
+      estimate_tree_cbh <- T
+    }
+    if(hmd_estimate_missing_hmd){
+      estimate_tree_hmd <- T
     }
   ####################################################################
   # check external data

--- a/R/cloud2trees.R
+++ b/R/cloud2trees.R
@@ -125,6 +125,7 @@ cloud2trees <- function(
   , chm_res_m = 0.25
   , min_height = 2
   , max_height = 70
+  , noise_level = 2
   , ws = itd_ws_functions()[["log_fn"]]
   , estimate_tree_dbh = FALSE
   , max_dbh = 2
@@ -266,6 +267,7 @@ cloud2trees <- function(
       , chm_res_m = chm_res_m
       , min_height = min_height
       , max_height = max_height
+      , noise_level = noise_level
       , overwrite = overwrite
   )
   # cloud2raster_ans %>% names()
@@ -1016,6 +1018,7 @@ cloud2trees <- function(
             , sttng_chm_res_m = chm_res_m
             , sttng_min_height = min_height
             , sttng_max_height = max_height
+            , sttng_noise_level = noise_level
             , sttng_ws = as.character(deparse(ws)) %>% paste(collapse = "") %>% stringr::str_trim()
             , sttng_estimate_tree_dbh = estimate_tree_dbh
             , sttng_max_dbh = max_dbh

--- a/R/lasr_pipeline.R
+++ b/R/lasr_pipeline.R
@@ -130,6 +130,7 @@ lasr_pipeline <- function(
           # # coarse-scale filter with 50 neighbors to find points/clusters
           # # statistically far from the main cloud mass
           lasR::classify_with_sor(k =  50, m = 4) +
+          lasR::delete_noise() +
           # # fine-scale filter with 15 neighbors and a tighter threshold of 3 sd's
           # # (3-sigma rule) to find outlier points based on local neighborhood
           lasR::classify_with_sor(k =  15, m = 3) +

--- a/R/lasr_pipeline.R
+++ b/R/lasr_pipeline.R
@@ -10,6 +10,14 @@
 #' @param chm_res_m numeric. The desired resolution of the CHM produced in meters.
 #' @param min_height numeric. Set the minimum height (m) for individual tree detection
 #' @param max_height numeric. Set the maximum height (m) for the canopy height model
+#' @param noise_level numeric. Choose point cloud noise reduction level 1, 2, or 3. Use a higher noise level for point clouds with more noise
+#'    which tend to produce raster outputs with pits or spikes that are too severe to be filled with standard post-processing.
+#'    The default level of 2 has similar processing time compared to level to 1
+#'    but uses a more broadly applicable noise detection algorithm. Level 3 takes 10-40% longer to process.
+#'   * noise_level = 1 uses isolated voxel filter (IVF) with a resolution of 5 voxels and 9 other points to identify noise
+#'   * noise_level = 2 uses a single-pass, fine-scale statistical outlier removal (SOR) that primarily targets local noise
+#'   * noise_level = 3 uses a muli-pass statistical outlier removal (SOR) that first applies a coarse-scale filter
+#'    to find points/clusters far from the main cloud mass and then applies a fine-scale filter to identify local noise
 #' @param dtm_dir string. The path of a folder to write the tiled DTM files to.
 #' @param chm_dir string. The path of a folder to write the tiled CHM files to.
 #' @param classify_dir string. The path of a folder to write the classified .las files to.
@@ -31,6 +39,7 @@ lasr_pipeline <- function(
   , chm_res_m = 0.25
   , min_height = 2
   , max_height = 70
+  , noise_level = 2
   , dtm_dir = getwd()
   , chm_dir = getwd()
   , classify_dir = getwd()
@@ -110,15 +119,29 @@ lasr_pipeline <- function(
     ###################
     # denoise
     ###################
-      # classify isolated points
-      lasr_denoise <-
-        # # coarse-scale filter with 50 neighbors to find points/clusters
-        # # statistically far from the main cloud mass
-        # lasR::classify_with_sor(k =  50, m = 4) +
-        # # fine-scale filter with 15 neighbors and a tighter threshold of 3 sd's
-        # # (3-sigma rule) to find outlier points based on local neighborhood
-        lasR::classify_with_sor(k =  15, m = 3) +
-        lasR::delete_noise()
+      if(as.numeric(noise_level)==1){
+        # classify isolated points
+        lasr_denoise <-
+          lasR::classify_with_ivf(res = 5, n = 9L) +
+          lasR::delete_noise()
+      }else if(as.numeric(noise_level)==3){
+        # classify isolated points
+        lasr_denoise <-
+          # # coarse-scale filter with 50 neighbors to find points/clusters
+          # # statistically far from the main cloud mass
+          lasR::classify_with_sor(k =  50, m = 4) +
+          # # fine-scale filter with 15 neighbors and a tighter threshold of 3 sd's
+          # # (3-sigma rule) to find outlier points based on local neighborhood
+          lasR::classify_with_sor(k =  15, m = 3) +
+          lasR::delete_noise()
+      }else{
+        # classify isolated points
+        lasr_denoise <-
+          # # fine-scale filter with 15 neighbors and a tighter threshold of 3 sd's
+          # # (3-sigma rule) to find outlier points based on local neighborhood
+          lasR::classify_with_sor(k =  15, m = 3) +
+          lasR::delete_noise()
+      }
     ###################
     # write
     ###################

--- a/R/lasr_pipeline.R
+++ b/R/lasr_pipeline.R
@@ -111,7 +111,14 @@ lasr_pipeline <- function(
     # denoise
     ###################
       # classify isolated points
-      lasr_denoise <- lasR::classify_with_ivf(res =  5, n = 9L) + lasR::delete_noise()
+      lasr_denoise <-
+        # # coarse-scale filter with 50 neighbors to find points/clusters
+        # # statistically far from the main cloud mass
+        # lasR::classify_with_sor(k =  50, m = 4) +
+        # # fine-scale filter with 15 neighbors and a tighter threshold of 3 sd's
+        # # (3-sigma rule) to find outlier points based on local neighborhood
+        lasR::classify_with_sor(k =  15, m = 3) +
+        lasR::delete_noise()
     ###################
     # write
     ###################
@@ -135,7 +142,6 @@ lasr_pipeline <- function(
       lasr_pipeline_temp <- lasr_read +
         lasr_denoise +
         lasr_classify +
-        lasr_denoise +
         lasr_write_classify +
         lasr_dtm_norm(
           dtm_file_name = dtm_file_name
@@ -156,7 +162,6 @@ lasr_pipeline <- function(
       lasr_pipeline_temp <- lasr_read +
         lasr_denoise +
         lasr_classify +
-        lasr_denoise +
         lasr_dtm_norm(
           dtm_file_name = dtm_file_name
           , frac_for_tri = frac_for_tri

--- a/R/trees_dbh.R
+++ b/R/trees_dbh.R
@@ -235,7 +235,9 @@ trees_dbh <- function(
       sf::st_buffer(boundary_buffer)
   }
   #check trees vs boundary
-  nintersect <- tree_tops %>% sf::st_intersection(buff) %>% nrow() %>% dplyr::coalesce(0)
+  nintersect <- suppressWarnings(
+    tree_tops %>% sf::st_intersection(buff) %>% nrow() %>% dplyr::coalesce(0)
+  )
   if(nintersect==0){
     stop(paste0(
       "No trees in `tree_list` are within the `study_boundary`. DBH not estimated.\n"
@@ -422,15 +424,17 @@ trees_dbh <- function(
       )
 
       # non-linear model form with Gamma distribution for strictly positive response variable dbh
-      mod_nl_pop <- brms::brm(
-        formula = dbh_formula
-        , data = treemap_trees_df
-        , prior = dbh_priors
-        , family = brms::brmsfamily("Gamma")
-        , iter = 6000, warmup = 3000, chains = 4
-        , cores = lasR::half_cores()
-        , file = paste0(normalizePath(outfolder), "/regional_dbh_height_model")
-        , file_refit = "always"
+      mod_nl_pop <- suppressWarnings(
+        brms::brm(
+          formula = dbh_formula
+          , data = treemap_trees_df
+          , prior = dbh_priors
+          , family = brms::brmsfamily("Gamma")
+          , iter = 6000, warmup = 3000, chains = 4
+          , cores = lasR::half_cores()
+          , file = paste0(normalizePath(outfolder), "/regional_dbh_height_model")
+          , file_refit = "always"
+        )
       )
       # plot(mod_nl_pop)
       # summary(mod_nl_pop)
@@ -462,16 +466,18 @@ trees_dbh <- function(
         # as trees get larger, the variance in their diameter typically increases.
         # the lognormal distribution naturally accounts for this because it assumes the
         # error is multiplicative rather than additive, and it ensures that predicted DBH values are always strictly positive.
-      mod_nl_pop <- brms::brm(
-        formula = dbh_formula
-        , data = treemap_trees_df
-        , prior = dbh_priors
-        , family = brms::lognormal()
-        , iter = 6000, warmup = 3000, chains = 4
-        , cores = lasR::half_cores()
-        , file = paste0(normalizePath(outfolder), "/regional_dbh_height_model")
-        , file_refit = "always"
-        , control = list(adapt_delta = 0.98)
+      mod_nl_pop <- suppressWarnings(
+        brms::brm(
+          formula = dbh_formula
+          , data = treemap_trees_df
+          , prior = dbh_priors
+          , family = brms::lognormal()
+          , iter = 6000, warmup = 3000, chains = 4
+          , cores = lasR::half_cores()
+          , file = paste0(normalizePath(outfolder), "/regional_dbh_height_model")
+          , file_refit = "always"
+          , control = list(adapt_delta = 0.98)
+        )
       )
       # plot(mod_nl_pop)
       # summary(mod_nl_pop)
@@ -586,7 +592,8 @@ trees_dbh <- function(
       ###________________________________________________________###
         ### Join the top down crowns with the stem location points
         ## !! Note that one crown can have multiple stems within its bounds
-      crowns_sf_joined_stems_temp <- tree_list %>%
+      crowns_sf_joined_stems_temp <- suppressWarnings(
+        tree_list %>%
         sf::st_join(
           treels_dbh_locations %>%
             # rename all columns to have "stem" prefix
@@ -599,6 +606,7 @@ trees_dbh <- function(
               ]
             )
         )
+      )
       if(
         max(grepl("tree_x", names(crowns_sf_joined_stems_temp)))==0
         | max(grepl("tree_y", names(crowns_sf_joined_stems_temp)))==0
@@ -731,16 +739,18 @@ trees_dbh <- function(
           }else{
             # population model with no random effects (i.e. no group-level variation)
             # Gamma distribution for strictly positive response variable dbh
-            stem_prediction_model <- brms::brm(
-              formula = stem_dbh_cm ~ 1 + tree_height_m
-              , data = dbh_training_data_temp %>%
-                  dplyr::select(stem_dbh_cm, tree_height_m)
-              , family = brms::brmsfamily("Gamma", link = "log")
-              , prior = c(brms::prior(gamma(0.01, 0.01), class = shape))
-              , iter = 4000, warmup = 2000, chains = 4
-              , cores = lasR::half_cores()
-              , file = paste0(normalizePath(outfolder), "/local_dbh_height_model")
-              , file_refit = "always"
+            stem_prediction_model <- suppressWarnings(
+              brms::brm(
+                formula = stem_dbh_cm ~ 1 + tree_height_m
+                , data = dbh_training_data_temp %>%
+                    dplyr::select(stem_dbh_cm, tree_height_m)
+                , family = brms::brmsfamily("Gamma", link = "log")
+                , prior = c(brms::prior(gamma(0.01, 0.01), class = shape))
+                , iter = 4000, warmup = 2000, chains = 4
+                , cores = lasR::half_cores()
+                , file = paste0(normalizePath(outfolder), "/local_dbh_height_model")
+                , file_refit = "always"
+              )
             )
           }
           ###___________________________________________________________________###

--- a/man/cloud2raster.Rd
+++ b/man/cloud2raster.Rd
@@ -20,6 +20,7 @@ cloud2raster(
   chm_res_m = 0.25,
   min_height = 2,
   max_height = 70,
+  noise_level = 2,
   overwrite = TRUE
 )
 }
@@ -56,6 +57,17 @@ accuracy_level = 3 uses triangulation with very high point density (100 pts/m2) 
 \item{min_height}{numeric. Set the minimum height (m) for individual tree detection}
 
 \item{max_height}{numeric. Set the maximum height (m) for the canopy height model}
+
+\item{noise_level}{numeric. Choose point cloud noise reduction level 1, 2, or 3. Use a higher noise level for point clouds with more noise
+which tend to produce raster outputs with pits or spikes that are too severe to be filled with standard post-processing.
+The default level of 2 has similar processing time compared to level to 1
+but uses a more broadly applicable noise detection algorithm. Level 3 takes 10-40\% longer to process.
+\itemize{
+\item noise_level = 1 uses isolated voxel filter (IVF) with a resolution of 5 voxels and 9 other points to identify noise
+\item noise_level = 2 uses a single-pass, fine-scale statistical outlier removal (SOR) that primarily targets local noise
+\item noise_level = 3 uses a muli-pass statistical outlier removal (SOR) that first applies a coarse-scale filter
+to find points/clusters far from the main cloud mass and then applies a fine-scale filter to identify local noise
+}}
 
 \item{overwrite}{logical. Should the output files in the \code{point_cloud_processing_delivery} directory from previous iterations be deleted?}
 }

--- a/man/cloud2raster.Rd
+++ b/man/cloud2raster.Rd
@@ -71,7 +71,7 @@ The order of operations is:
 \itemize{
 \item Tile the raw point cloud to work with smaller chunks and reduce the potential for memory issues with high density clouds using \code{\link[=chunk_las_catalog]{chunk_las_catalog()}}
 \item Classify the point cloud using \code{\link[lasR:classify_with_csf]{lasR::classify_with_csf()}}
-\item Remove outlier points using \code{\link[lasR:classify_with_ivf]{lasR::classify_with_ivf()}}
+\item Remove outlier points using \code{\link[lasR:classify_with_sor]{lasR::classify_with_sor()}}
 \item Produce a triangulation of the ground points (meshed DTM) using \code{\link[lasR:triangulate]{lasR::triangulate()}}
 \item Rasterize the result of the Delaunay triangulation using \code{\link[lasR:rasterize]{lasR::rasterize()}} to create a DTM
 \item Height normalize the point cloud using either the DTM or the triangulation \code{\link[lasR:transform_with]{lasR::transform_with()}}

--- a/man/cloud2trees.Rd
+++ b/man/cloud2trees.Rd
@@ -21,6 +21,7 @@ cloud2trees(
   chm_res_m = 0.25,
   min_height = 2,
   max_height = 70,
+  noise_level = 2,
   ws = itd_ws_functions()[["log_fn"]],
   estimate_tree_dbh = FALSE,
   max_dbh = 2,
@@ -91,6 +92,17 @@ accuracy_level = 3 uses triangulation with very high point density (100 pts/m2) 
 \item{min_height}{numeric. Set the minimum height (m) for individual tree detection}
 
 \item{max_height}{numeric. Set the maximum height (m) for the canopy height model}
+
+\item{noise_level}{numeric. Choose point cloud noise reduction level 1, 2, or 3. Use a higher noise level for point clouds with more noise
+which tend to produce raster outputs with pits or spikes that are too severe to be filled with standard post-processing.
+The default level of 2 has similar processing time compared to level to 1
+but uses a more broadly applicable noise detection algorithm. Level 3 takes 10-40\% longer to process.
+\itemize{
+\item noise_level = 1 uses isolated voxel filter (IVF) with a resolution of 5 voxels and 9 other points to identify noise
+\item noise_level = 2 uses a single-pass, fine-scale statistical outlier removal (SOR) that primarily targets local noise
+\item noise_level = 3 uses a muli-pass statistical outlier removal (SOR) that first applies a coarse-scale filter
+to find points/clusters far from the main cloud mass and then applies a fine-scale filter to identify local noise
+}}
 
 \item{ws}{numeric or function. Length or diameter of the moving window used to detect the local
 maxima in the units of the input data (usually meters). If it is numeric a fixed window size is used.

--- a/man/cloud2trees.Rd
+++ b/man/cloud2trees.Rd
@@ -158,7 +158,7 @@ who found the dry bulk density of the tree crown was 2.6 kilograms per cubed met
 using Douglas-fir trees grown on Christmas tree farms.
 Set this parameter to a large value (e.g. 1e10) or NULL to avoid limiting tree crown CBD.}
 
-\item{estimate_tree_cbh}{logical. Should tree DBH be estimated? See \code{\link[=trees_cbh]{trees_cbh()}}.
+\item{estimate_tree_cbh}{logical. Should tree CBH be estimated? See \code{\link[=trees_cbh]{trees_cbh()}}.
 Make sure to set \code{cbh_estimate_missing_cbh = TRUE} if you want to obtain CBH values for cases when CBH cannot be extracted from the point cloud.}
 
 \item{cbh_tree_sample_n, cbh_tree_sample_prop}{numeric. Provide either \code{tree_sample_n}, the number of trees, or \code{tree_sample_prop}, the

--- a/man/lasr_pipeline.Rd
+++ b/man/lasr_pipeline.Rd
@@ -12,6 +12,7 @@ lasr_pipeline(
   chm_res_m = 0.25,
   min_height = 2,
   max_height = 70,
+  noise_level = 2,
   dtm_dir = getwd(),
   chm_dir = getwd(),
   classify_dir = getwd(),
@@ -32,6 +33,17 @@ lasr_pipeline(
 \item{min_height}{numeric. Set the minimum height (m) for individual tree detection}
 
 \item{max_height}{numeric. Set the maximum height (m) for the canopy height model}
+
+\item{noise_level}{numeric. Choose point cloud noise reduction level 1, 2, or 3. Use a higher noise level for point clouds with more noise
+which tend to produce raster outputs with pits or spikes that are too severe to be filled with standard post-processing.
+The default level of 2 has similar processing time compared to level to 1
+but uses a more broadly applicable noise detection algorithm. Level 3 takes 10-40\% longer to process.
+\itemize{
+\item noise_level = 1 uses isolated voxel filter (IVF) with a resolution of 5 voxels and 9 other points to identify noise
+\item noise_level = 2 uses a single-pass, fine-scale statistical outlier removal (SOR) that primarily targets local noise
+\item noise_level = 3 uses a muli-pass statistical outlier removal (SOR) that first applies a coarse-scale filter
+to find points/clusters far from the main cloud mass and then applies a fine-scale filter to identify local noise
+}}
 
 \item{dtm_dir}{string. The path of a folder to write the tiled DTM files to.}
 


### PR DESCRIPTION
- Change: introduces `noise_level` parameter to `cloud2raster()` and `cloud2trees()` to update the point cloud noise filtering workflow and gives users control over the algorithm and strictness used to better address persistent raster artifacts.
- Change: `cloud2trees()` checks to ensure alignment between the `*_estimate_missing_*` and `estimate_tree_*` parameters. If `cbh_estimate_missing_cbh = T`, then the program automatically enables `estimate_tree_cbh` and the same applies for the `hmd_` settings. Users should still define a sample size (`*_tree_sample_n` or `*_tree_sample_prop`) for estimating these tree attributes, if none is defined the default is to use a small sample for estimation to limit processing time.

`noise_level` is a tiered parameter added to `cloud2raster()` and `cloud2trees()` which gives users control over the noise detection algorithm and strictness used to resolve artifacts in rasterized data products. The new options include a statistical outlier removal (SOR) algorithm which identifies noise by calculating the mean distance from each point to its nearest neighbors. The workflow continues to remove all vendor-classified noise from the raw point cloud prior to subsequent processing. The `noise_level` allows users to control additional noise cleaning based on the specific quality of the dataset. This provides users with a way to mitigate issues if initial rasterized outputs (CHM, DTM) include persistent pits or spikes. `noise_level = 2` (the default) uses a fine-scale SOR filter with 15 neighbors and a 3 standard deviation threshold (3-sigma rule) to find outliers based on the local neighborhood. `noise_level = 3` adds a global noise detection pass prior to the local pass by first using 50 neighbors to identify points or clusters that are statistically far from the main cloud mass. While `noise_level = 2` does not consistently increase processing time, `noise_level = 3` will generally result in longer runtimes, especially for high-density data, because it is a multi-scale noise removal routine that analyzes larger groups of points simultaneously.

**`noise_level` settings:**

1. `noise_level = 1` (legacy): uses `lasR::classify_with_ivf(res = 5, n = 9)` and is maintained for legacy consistency and backward compatibility.
2. `noise_level = 2` (fine-scale SOR): the default setting implements `lasR::classify_with_sor()` with a neighborhood of 15 points (k = 15) and a threshold of 3 standard deviations (m = 3) is used for standard cleaning across varying point densities.
3. `noise_level = 3` (multi-scale SOR): uses a dual-pass noise filtering approach by first applying a coarse-scale filter (k = 50, m = 4) to identify points or clusters that are far from the main cloud mass and then a fine-scale filter (k = 15, m = 3) for local cleaning.