### PR TITLE
Updates to landfire 2024

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Aerial point cloud data to forest inventory tree lists
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: 
     person("George", "Woolsey", , "george.woolsey@colostate.edu", role = c("aut", "cre"))
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # cloud2trees 0.8.2
 
+Updates to use LANDFIRE CBD 2024 vintage ([https://landfire.gov/fuel/cbd](https://landfire.gov/fuel/cbd)) and eliminates need to users to process the data post-download to convert factor raster to numeric values by hosting a pre-cleaned variant on [Zenodo](https://zenodo.org/records/19684623).
+
+Users should update to this new data using: 
+
+```r
+get_landfire(force = T)
+```
+
+- Change: to enable `cloud2trees_to_lanl_trees()` generation of LANL inputs without a DTM file, setting `topofile = 'flat'` no longer requires a DTM file to exist within the folder path of `input_dir`. The updates result in the following outcomes:
+
+  * `topofile = 'flat'` and DTM raster file (e.g. 'dtm_*.tif') not found within `input_dir`: 'topo.dat' file is not created and `topofile` is set to 'flat' in the fuellist file.
+  * `topofile = 'flat'` and DTM raster file (e.g. 'dtm_*.tif') found within `input_dir`: 'topo.dat' file is created and `topofile` is set to 'flat' in the fuellist file.
+  * `topofile = 'dtm'` and DTM raster file (e.g. 'dtm_*.tif') not found within `input_dir`: ERROR.
+  * `topofile = 'dtm'` and DTM raster file (e.g. 'dtm_*.tif') found within `input_dir`: 'topo.dat' file is created and `topofile` is set to the path of the 'topo.dat' in the fuellist file.
+
 # cloud2trees 0.8.1
 
 - New: adds new internal workflow relevant to forest management for potential future release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.8.2
+
 # cloud2trees 0.8.1
 
 - New: adds new internal workflow relevant to forest management for potential future release

--- a/R/cloud2trees_to_lanl_trees.R
+++ b/R/cloud2trees_to_lanl_trees.R
@@ -143,6 +143,7 @@ cloud2trees_to_lanl_trees <- function(
       ))}
     #### dtm
       if(
+        topofile=="dtm" &&
         is.null(search_dir_final_detected_ans$dtm_flist)
       ){stop(paste0(
         "could not locate DTM raster in:\n    "
@@ -258,13 +259,24 @@ cloud2trees_to_lanl_trees <- function(
   #######################################
   # quicfire_dtm_topofile
   #######################################
-    # don't forget the fortran flipped over rast
-    quicfire_dtm_topofile_ans <- quicfire_dtm_topofile(
-      dtm_rast = search_dir_final_detected_ans$dtm_flist[1]
-      , horizontal_resolution = horizontal_res
-      , study_boundary = quicfire_domain_df$quicfire_domain_df
-      , outdir = outdir
-    )
+    if(
+      topofile=="dtm" ||
+      !is.null(search_dir_final_detected_ans$dtm_flist[1])
+    ){
+      # don't forget the fortran flipped over rast
+      quicfire_dtm_topofile_ans <- quicfire_dtm_topofile(
+        dtm_rast = search_dir_final_detected_ans$dtm_flist[1]
+        , horizontal_resolution = horizontal_res
+        , study_boundary = quicfire_domain_df$quicfire_domain_df
+        , outdir = outdir
+      )
+    }else{
+      quicfire_dtm_topofile_ans <-
+        list(
+          dtm = NULL
+          , topofile_path = NULL
+        )
+    }
     # quicfire_dtm_topofile_ans
     # quicfire_dtm_topofile_ans$topofile_path
     # terra::plot(quicfire_dtm_topofile_ans$dtm)

--- a/R/get_foresttype.R
+++ b/R/get_foresttype.R
@@ -57,11 +57,13 @@ get_foresttype <- function(
     # where was this written?
     fff <- file.path(my_savedir, my_my_name)
     # write a csv to package directory with location of data
-    dplyr::tibble(location = fff) %>%
-      write.csv(
-        file.path(pkg_dir, "location_foresttype.csv")
-        , row.names = F
-        , append = F
-      )
+    suppressWarnings(suppressMessages({
+      dplyr::tibble(location = fff) %>%
+        write.csv(
+          file.path(pkg_dir, "location_foresttype.csv")
+          , row.names = F
+          , append = F
+        )
+    }))
   }
 }

--- a/R/get_landfire.R
+++ b/R/get_landfire.R
@@ -22,7 +22,7 @@ get_landfire <- function(
   # filename !!!!!!!!!!!!! landfire only
   ff_name <- "lc23_cbd_240.tif"
   # set up parameters to pass to get_url_data()
-  my_eval_url <- "https://landfire.gov/data-downloads/US_240/LF2023_CBD_240_CONUS.zip"
+  my_eval_url <- "https://zenodo.org/records/19684623/files/landfire_cbd_numeric.zip?download=1"
   my_my_name <- "landfire"
   my_req_file_list <- c(ff_name)
   my_cleanup_zip <- T
@@ -53,27 +53,13 @@ get_landfire <- function(
     # where was this written?
     fff <- file.path(my_savedir, my_my_name)
     # write a csv to package directory with location of data
-    dplyr::tibble(location = fff) %>%
-      write.csv(
-        file.path(pkg_dir, "location_landfire.csv")
-        , row.names = F
-        , append = F
-      )
-
-    ##### !!!!!!!!! for landfire only...
-    ##### !!!!!!!!! the original data is factor type
-    ##### !!!!!!!!! the first time we download this data we'll clean it
-    ##### !!!!!!!!! by converting the data to numeric and transforming the values
-    # reclass_landfire_rast() defined in utils_rast_points.R
-    fff_name <- file.path(fff, ff_name)
-    safe_reclass_landfire_rast <- purrr::safely(reclass_landfire_rast)
-    rcl <- safe_reclass_landfire_rast(rast = terra::rast(fff_name))
-    if(is.null(rcl$error)){
-      message("unpacking LANDFIRE data...this might take a while (24-98 mins.)")
-      terra::writeRaster(rcl$result, filename = fff_name, overwrite = T)
-      message("LANDFIRE raster successfully downloaded and unpacked")
-    }else{
-      warning("LANDFIRE raster successfully downloaded and but not fully unpacked...proceed with caution")
-    }
+    suppressWarnings(suppressMessages({
+      dplyr::tibble(location = fff) %>%
+        write.csv(
+          file.path(pkg_dir, "location_landfire.csv")
+          , row.names = F
+          , append = F
+        )
+    }))
   }
 }

--- a/R/get_treemap.R
+++ b/R/get_treemap.R
@@ -54,12 +54,14 @@ get_treemap <- function(
     # where was this written?
     fff <- file.path(my_savedir, my_my_name)
     # write a csv to package directory with location of data
-    dplyr::tibble(location = fff) %>%
-      write.csv(
-        file.path(pkg_dir, "location_treemap.csv")
-        , row.names = F
-        , append = F
-      )
+    suppressWarnings(suppressMessages({
+      dplyr::tibble(location = fff) %>%
+        write.csv(
+          file.path(pkg_dir, "location_treemap.csv")
+          , row.names = F
+          , append = F
+        )
+    }))
   }
 }
 ### intermediate function to return the flist

--- a/R/utils_lanl_trees.R
+++ b/R/utils_lanl_trees.R
@@ -224,12 +224,14 @@ quicfire_define_domain <- function(
   # write it
   # writes to geojson in WGS84
   fp <- file.path(normalizePath(outdir),"Lidar_Bounds.geojson")
-  sf::st_write(
-    bbox
-    , fp
-    , driver = "GeoJSON"
-    , delete_dsn = TRUE
-  )
+  suppressWarnings(suppressMessages({
+    sf::st_write(
+      bbox
+      , fp
+      , driver = "GeoJSON"
+      , delete_dsn = TRUE
+    )
+  }))
 
   message(paste0(
     "exported QUIC-Fire domain to:"


### PR DESCRIPTION
Updates to use LANDFIRE CBD 2024 vintage ([https://landfire.gov/fuel/cbd](https://landfire.gov/fuel/cbd)) and eliminates need to users to process the data post-download to convert factor raster to numeric values by hosting a pre-cleaned variant on [Zenodo](https://zenodo.org/records/19684623).

Users should update to this new data using: 

```r
get_landfire(force = T)
```

- Change: to enable `cloud2trees_to_lanl_trees()` generation of LANL inputs without a DTM file, setting `topofile = 'flat'` no longer requires a DTM file to exist within the folder path of `input_dir`. The updates result in the following outcomes:

  * `topofile = 'flat'` and DTM raster file (e.g. 'dtm_*.tif') not found within `input_dir`: 'topo.dat' file is not created and `topofile` is set to 'flat' in the fuellist file.
  * `topofile = 'flat'` and DTM raster file (e.g. 'dtm_*.tif') found within `input_dir`: 'topo.dat' file is created and `topofile` is set to 'flat' in the fuellist file.
  * `topofile = 'dtm'` and DTM raster file (e.g. 'dtm_*.tif') not found within `input_dir`: ERROR.
  * `topofile = 'dtm'` and DTM raster file (e.g. 'dtm_*.tif') found within `input_dir`: 'topo.dat' file is created and `topofile` is set to the path of the 'topo.dat' in the fuellist file.