### PR TITLE
updates link in `get_treemap()` (fixes #47)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cloud2trees
 Title: Aerial point cloud data to forest inventory tree lists
-Version: 0.8.2
+Version: 0.8.3
 Authors@R: 
     person("George", "Woolsey", , "george.woolsey@colostate.edu", role = c("aut", "cre"))
 Description: Extract a tree list, CHM, DTM, and more from .las|.laz point

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cloud2trees 0.8.3
+
 # cloud2trees 0.8.2
 
 Updates to use LANDFIRE CBD 2024 vintage ([https://landfire.gov/fuel/cbd](https://landfire.gov/fuel/cbd)) and eliminates need to users to process the data post-download to convert factor raster to numeric values by hosting a pre-cleaned variant on [Zenodo](https://zenodo.org/records/19684623).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cloud2trees 0.8.3
 
+- Change/Fix: [TreeMap 2022](https://doi.org/10.2737/RDS-2025-0032) download link updated in `get_treemap()` to match updated link in the "Research Data Archive" (@JosephSilva19, #47).
+
+  * **archive** as in *"a place in which public records or historical materials (such as documents) are preserved"* ([Merriam-Webster](https://www.merriam-webster.com/dictionary/archive), accessed August 20, 2026)
+
 # cloud2trees 0.8.2
 
 Updates to use LANDFIRE CBD 2024 vintage ([https://landfire.gov/fuel/cbd](https://landfire.gov/fuel/cbd)) and eliminates need to users to process the data post-download to convert factor raster to numeric values by hosting a pre-cleaned variant on [Zenodo](https://zenodo.org/records/19684623).

--- a/R/get_treemap.R
+++ b/R/get_treemap.R
@@ -21,9 +21,10 @@ get_treemap <- function(
   , force = F
 ){
   # set up parameters to pass to get_url_data()
-    # older url: "https://s3-us-west-2.amazonaws.com/fs.usda.rds/RDS-2021-0074/RDS-2021-0074_Data.zip"
-    # old url: "https://usfs-public.box.com/shared/static/yz7h8b8v92scoqfwukjyulokaevzo6v6.zip"
-  my_eval_url <- "https://usfs-public.box.com/shared/static/c4pv6jamvxjdbzgezztvs43bqudigwaq.zip" # updated 2025-07-24
+    # even older url: "https://s3-us-west-2.amazonaws.com/fs.usda.rds/RDS-2021-0074/RDS-2021-0074_Data.zip"
+    # older url: "https://usfs-public.box.com/shared/static/yz7h8b8v92scoqfwukjyulokaevzo6v6.zip"
+    # old url: "https://usfs-public.box.com/shared/static/c4pv6jamvxjdbzgezztvs43bqudigwaq.zip"
+  my_eval_url <- "https://usfs-public.box.com/shared/static/jaayceyk4i5vl484fuopbnssy017r6v9.zip" # updated 2025-08-21
   my_my_name <- "treemap"
   my_req_file_list <- treemap2022() # c("treemap2022_conus.tif", "treemap2022_conus_tree_table.csv")
   my_cleanup_zip <- T

--- a/man/piles_quantify.Rd
+++ b/man/piles_quantify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/piles_quantify.R
 \name{piles_quantify}
 \alias{piles_quantify}
-\title{Spectral filtering of candidate slash piles}
+\title{CHM-based quantification of polygon objects}
 \usage{
 piles_quantify(sf_poly, chm_rast)
 }


### PR DESCRIPTION
- Change/Fix: [TreeMap 2022](https://doi.org/10.2737/RDS-2025-0032) download link updated in `get_treemap()` to match updated link in the "Research Data Archive" (@JosephSilva19, #47 ).

  * **archive** as in *"a place in which public records or historical materials (such as documents) are preserved"* ([Merriam-Webster](https://www.merriam-webster.com/dictionary/archive), accessed August 20, 2026)
