### PR TITLE
fix Node.js 20 deprecated in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,13 +23,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -42,7 +40,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,8 @@ Remotes:
     github::olgaviedma/LadderFuelsR,
     github::r-lidar/lasR,
     github::tiagodc/TreeLS
-Config/Needs/website: rmarkdown
+Additional_repositories: https://r-universe.dev
+Config/Needs/website: lasR, lidR, rlas
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,14 +21,14 @@ Imports:
     LadderFuelsR (>= 0.0.7),
     lasR (>= 0.13.1),
     leafR (>= 0.3.5),
-    lidR,
+    lidR (>= 4.2.3),
     lifecycle,
     magrittr,
     purrr,
     randomForest,
     readr,
     rlang,
-    rlas,
+    rlas (>= 1.8.4),
     scales,
     sf,
     stats,
@@ -57,9 +57,10 @@ Remotes:
     github::DRAAlmeida/leafR,
     github::olgaviedma/LadderFuelsR,
     github::r-lidar/lasR,
+    github::r-lidar/lidR,
+    github::r-lidar/rlas,
     github::tiagodc/TreeLS
-Additional_repositories: https://r-universe.dev
-Config/Needs/website: lasR, lidR, rlas
+Config/Needs/website: rmarkdown
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
work on "Node.js 20 is deprecated..." from pkgdown workflow during merge request check:
>Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
