### PR TITLE
updating `rlas` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     randomForest,
     readr,
     rlang,
-    rlas (>= 1.8.4),
+    rlas (>= 1.8.0),
     scales,
     sf,
     stats,


### PR DESCRIPTION
updating min `rlas` version since it was [removed from CRAN](https://cran.r-project.org/web/packages/rlas/index.html)